### PR TITLE
Make package work with isolated build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,17 @@
 # set up the project #
 ######################
 cmake_minimum_required(VERSION 3.5.1)
+project(pybind11_catkin)
 
 # required to use std::shared_ptr in code and to link the python bindings
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")
 endif()
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 
-project(pybind11_catkin)
+# use C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # ensuring path to libraries are set during install
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -17,29 +20,26 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 
-################################################
-# Load the local pybind11 download throw treep #
-################################################
+##################################################
+# Load the local pybind11 download through treep #
+##################################################
 
-set(pybind11_treep_clone_dir "${CMAKE_SOURCE_DIR}/not_catkin/third_party/pybind11")
-add_subdirectory(${pybind11_treep_clone_dir} tmp_${PROJECT_NAME})
-
-###############################################
-# For cmake to find the FindXXXXX.cmake files #
-###############################################
-
-list(APPEND CMAKE_MODULE_PATH "${pybind11_treep_clone_dir}/tools/")
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
+# TODO move pybind11 next to this directory to simplify the relative path
+# FIXME will this also work in install space?
+set(PYBIND11_SOURCE_PATH "${PROJECT_SOURCE_DIR}/../../../not_catkin/third_party/pybind11")
 
 ##########################################
 # export the package as a catkin package #
 ##########################################
 
+find_package(catkin REQUIRED COMPONENTS
+    mpi_cmake_modules)
+
 catkin_package(
-  INCLUDE_DIRS ${pybind11_treep_clone_dir}/include
-  LIBRARIES
-  CFG_EXTRAS ${pybind11_treep_clone_dir}/tools/pybind11Tools.cmake
-)
+    INCLUDE_DIRS ${PYBIND11_SOURCE_PATH}/include
+    LIBRARIES
+    CFG_EXTRAS pybind11_tools.cmake
+    )
 
 ##########################
 # building documentation #

--- a/cmake/pybind11_tools.cmake.in
+++ b/cmake/pybind11_tools.cmake.in
@@ -1,0 +1,3 @@
+# Provide cmake files from pybind11
+list(APPEND CMAKE_MODULE_PATH "@PYBIND11_SOURCE_PATH@/tools/")
+include(@PYBIND11_SOURCE_PATH@/tools/pybind11Tools.cmake)

--- a/package.xml
+++ b/package.xml
@@ -5,9 +5,11 @@
   <description>Package for generating python bindings</description>
   <maintainer email="mnaveau@tue.mpg.de"> Maximilien Naveau</maintainer>
   <license>BSD 3-Clause</license>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
-  
+
+  <build_depend>mpi_cmake_modules</build_depend>
+
   <export>
   </export>
 </package>


### PR DESCRIPTION
# Description

When using `catkin_make_isolated` or `catkin build`, the
`${CMAKE_SOURCE_DIR}` does not refer to the workspace root so this
cannot be used to construct the path to the pybind11 package in a
portable way.
As a workaround for now, specify the relative path from the root of this
package (determined via `${PROJECT_SOURCE_DIR}`).

Since setting `CMAKE_MODULE_PATH` for the parent scope won't work
either, use a template file which will get the absolute path set during
build and use this for CFG_EXTRAS.

Remove the `add_subdirectory` call which does not seem to be necessary.