### PR TITLE
Vberenz/find pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 
 # TODO move pybind11 next to this directory to simplify the relative path
 # FIXME will this also work in install space?
-set(PYBIND11_SOURCE_PATH "${PROJECT_SOURCE_DIR}/../../../not_catkin/third_party/pybind11")
+set(PYBIND11_SOURCE_PATH "${PROJECT_SOURCE_DIR}/../../third_party/pybind11")
 
 ##########################################
 # export the package as a catkin package #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,15 @@ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 # Load the local pybind11 download through treep #
 ##################################################
 
-# TODO move pybind11 next to this directory to simplify the relative path
 # FIXME will this also work in install space?
-set(PYBIND11_SOURCE_PATH "${PROJECT_SOURCE_DIR}/../../third_party/pybind11")
+EXEC_PROGRAM(${CMAKE_CURRENT_SOURCE_DIR}/scripts/find_pybind11
+  OUTPUT_VARIABLE pybind11_path RETURN_VALUE pybind11_found)
+
+if(NOT ${pybind11_found} MATCHES "0")
+  MESSAGE(FATAL_ERROR "pybind11_cmake: failed to find pybind11 anywhere in the source directory")
+endif()
+
+set(PYBIND11_SOURCE_PATH "${pybind11_path}")
 
 ##########################################
 # export the package as a catkin package #

--- a/scripts/find_pybind11
+++ b/scripts/find_pybind11
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import os,sys
+
+pybind11_g = "pybind11"
+
+def _find_src(starting_dir):
+
+    current  = starting_dir
+    while True:
+        current = os.path.abspath(current+os.sep+"..")
+        if os.path.basename(current) == "src" :
+            return os.path.abspath(current)
+        if not os.path.isdir(current):
+            break
+    raise Exception("src folder not found")
+
+def _find_pybind11(starting_dir):
+
+    src = _find_src(starting_dir)
+    for root,dirs,files in os.walk(src):
+        if pybind11_g in dirs:
+            return os.path.abspath(root+os.sep+pybind11_g)
+    raise Exception(pybind11_g+" not found")
+
+def _get_script_path():
+    full_path = os.path.abspath(__file__)
+    base = os.path.basename(full_path)
+    return os.path.abspath(full_path[:-len(base)])
+
+def _run():
+    try :
+        print(_find_pybind11(_get_script_path()))
+        return True
+    except Exception as e:
+        print(str(e))
+        return False
+
+if __name__ == "__main__":
+
+    success = _run()
+    if success :
+        sys.exit()
+    sys.exit(1)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The relative path to pybind11 was hard coded, which is error prone when refactoring treep configuration (e.g. changing cloning path to pybind11).
A python script is now called by cmake to find pybind11 folder.

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

I tried compilation and it worked. 

[//]: # "Explain how you tested your changes"


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] link to dependent pull request

