### PR TITLE
find_pybind11 calls python3 instead of python

### DIFF
--- a/scripts/find_pybind11
+++ b/scripts/find_pybind11
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ @namespace pybind11_catkin.find_pybind11
 (python) executable that either find and print the pybind11 directory


### PR DESCRIPTION

## Description

CMakeLists uses a python script (find_pybind11) to find the folder of pybind11.
This script is set as an executable that uses python.
I would like the script to work on a minimal ubuntu 18.04 installation, on which python is not necessarily installed (but python3) is, I replaced "python" by "python3".
This remains compatible with our official ubuntu 18.04 install.

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

Compiled ok (finding pybind11) on my 16.04 machine and an 18.04 image.



